### PR TITLE
fix: bad tls hosts dependency in ingress

### DIFF
--- a/charts/genoa/values.schema.json
+++ b/charts/genoa/values.schema.json
@@ -276,12 +276,12 @@
               "secretName": {
                 "type": "string"
               }
+            },
+            "dependencies": {
+              "enabled": ["hosts"]
             }
           }
         }
-      },
-      "dependencies": {
-        "enabled": ["hosts"]
       }
     },
     "nameOverride": {


### PR DESCRIPTION
Noticed that when you try to setup `config.ingress` it fails with a `depends on hosts` because the json-schema file had the `dependencies[hosts]` at the wrong level. It was supposed to be part of ingress.tls.hosts, not ingress.hosts. This makes the error go away when you install the helm chart.

Fixes issue #3 