### PR TITLE
fix(maxRetries): avoid chicken and egg problem when maxRetries is set to 0 for initial CR reconciles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.6.0
+VERSION ?= 0.6.1
 # Image URL to use all building/pushing image targets
 IMG ?= coveros/genoa:${VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/charts/genoa/values.yaml
+++ b/charts/genoa/values.yaml
@@ -9,7 +9,7 @@ deployments:
     image:
       repository: coveros/genoa
       pullPolicy: Always
-      tag: 0.6.0
+      tag: 0.6.1
     imagePullSecrets: []
     labels: {}
     annotations: {}

--- a/controllers/release_controller.go
+++ b/controllers/release_controller.go
@@ -136,7 +136,7 @@ func (r *ReleaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 	}
 
-	if cr.Status.FailureCount > cr.Spec.MaxRetries {
+	if (cr.Status.FailureCount >= cr.Spec.MaxRetries) && cr.Status.FailureCount != 0 {
 		r.Log.Info(fmt.Sprintf("%v has reached max reconcile limit, please update spec.maxRetries if you want to retry", req.NamespacedName))
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
This fixes the use case when a user wants to install a CR with only 1 retry. This is done by setting maxRetries to 0. It works like backOffLimit in a k8s job. 

Bug was, when spec.maxRetries is set to 0 and this is first reconcile, controller was checking the status failureCount number which by default is 0. So when both are 0, the controller would not reconcile the CR.

Every new reconcile for every new CR, the failureCount in status will always start with 0, so we need to exclude failureCount check when checking whether a CR maxRetries has been met.